### PR TITLE
🔒 [Security] Fix integer overflow in compression bound calculation

### DIFF
--- a/src/compress/mod.rs
+++ b/src/compress/mod.rs
@@ -1559,15 +1559,15 @@ impl Compressor {
     }
 
     pub fn deflate_compress_bound(size: usize) -> usize {
-        size + (size / 65535 + 1) * 5 + 10
+        size.saturating_add((size / 65535 + 1) * 5 + 10)
     }
 
     pub fn zlib_compress_bound(size: usize) -> usize {
-        ZLIB_MIN_OVERHEAD + Self::deflate_compress_bound(size)
+        ZLIB_MIN_OVERHEAD.saturating_add(Self::deflate_compress_bound(size))
     }
 
     pub fn gzip_compress_bound(size: usize) -> usize {
-        GZIP_MIN_OVERHEAD + Self::deflate_compress_bound(size)
+        GZIP_MIN_OVERHEAD.saturating_add(Self::deflate_compress_bound(size))
     }
 
     pub fn compress_zlib(&mut self, input: &[u8], output: &mut [u8]) -> (CompressResult, usize) {

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -135,3 +135,17 @@ fn test_buffer_reuse() {
     let decomp2 = d.decompress_deflate(&comp2, data2.len()).unwrap();
     assert_eq!(data2.to_vec(), decomp2);
 }
+#[test]
+fn test_compress_bound_overflow_check() {
+    let mut compressor = Compressor::new(1).unwrap();
+    let size = usize::MAX - 100;
+
+    let bound = compressor.deflate_compress_bound(size);
+    assert!(bound >= size);
+
+    let bound = compressor.zlib_compress_bound(size);
+    assert!(bound >= size);
+
+    let bound = compressor.gzip_compress_bound(size);
+    assert!(bound >= size);
+}


### PR DESCRIPTION
The `deflate_compress_bound` and related functions (`zlib_compress_bound`, `gzip_compress_bound`)
in `src/compress/mod.rs` were vulnerable to integer overflow when `size` is close to `usize::MAX`.
The calculation `size + overhead` could wrap around in release builds, resulting in a small value.
This could lead to insufficient buffer allocation.

This commit changes the addition to use `saturating_add`, which saturates the result to `usize::MAX`
instead of wrapping. This ensures that a large enough buffer size is requested (or allocation fails safely),
preventing the vulnerability.

Added regression tests in `tests/unit_tests.rs` to verify the fix.

---
*PR created automatically by Jules for task [10132193117930965716](https://jules.google.com/task/10132193117930965716) started by @404Setup*