### PR TITLE
🧹 Refactor duplicated bsr32 function into common module

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -69,3 +69,8 @@ pub const GZIP_OS_UNKNOWN: u8 = 255;
 pub const MIN_BLOCK_LENGTH: usize = 5000;
 pub const SOFT_MAX_BLOCK_LENGTH: usize = 300000;
 pub const SEQ_STORE_LENGTH: usize = 50000;
+
+#[inline(always)]
+pub fn bsr32(v: u32) -> u32 {
+    31 - v.leading_zeros()
+}

--- a/src/compress/mod.rs
+++ b/src/compress/mod.rs
@@ -49,10 +49,6 @@ struct BlockSplitStats {
     num_observations: u32,
 }
 
-#[inline(always)]
-fn bsr32(v: u32) -> u32 {
-    31 - v.leading_zeros()
-}
 
 impl BlockSplitStats {
     fn new() -> Self {

--- a/src/decompress/mod.rs
+++ b/src/decompress/mod.rs
@@ -822,10 +822,6 @@ impl Decompressor {
     }
 }
 
-#[inline(always)]
-fn bsr32(v: u32) -> u32 {
-    31 - v.leading_zeros()
-}
 
 #[inline(always)]
 fn make_decode_table_entry(decode_results: &[u32], sym: usize, len: u32) -> u32 {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
  * Duplicated `bsr32` function in `src/compress/mod.rs` and `src/decompress/mod.rs`.

💡 **Why:** How this improves maintainability
  * By moving the duplicated function to `src/common.rs` and making it public, we reduce code duplication and make the codebase easier to maintain. Any changes to `bsr32` (though unlikely for such a simple function) would only need to be made in one place.

✅ **Verification:** How you confirmed the change is safe
  * Ran `cargo check` to ensure no compilation errors.
  * Ran `cargo test` to ensure all tests pass and no functionality is broken.
  * Verified that `bsr32` is correctly imported via `use crate::common::*;` in both modules.

✨ **Result:** The improvement achieved
  * The `bsr32` function is now defined in a single location (`src/common.rs`) and reused across the codebase.

---
*PR created automatically by Jules for task [9525133450990115286](https://jules.google.com/task/9525133450990115286) started by @404Setup*