### PR TITLE
test: add unit tests for Compressor::compress_gzip_into

### DIFF
--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -149,3 +149,30 @@ fn test_compress_bound_overflow_check() {
     let bound = compressor.gzip_compress_bound(size);
     assert!(bound >= size);
 }
+
+#[test]
+fn test_compress_gzip_into_success() {
+    let mut compressor = Compressor::new(6).unwrap();
+    let mut decompressor = Decompressor::new();
+    let data = b"Hello world! This is a test string for gzip compression into buffer.";
+
+    let bound = compressor.gzip_compress_bound(data.len());
+    let mut output = vec![0u8; bound];
+
+    let size = compressor.compress_gzip_into(data, &mut output).unwrap();
+    assert!(size > 0);
+    assert!(size <= bound);
+
+    let decompressed = decompressor.decompress_gzip(&output[..size], data.len()).unwrap();
+    assert_eq!(data.to_vec(), decompressed);
+}
+
+#[test]
+fn test_compress_gzip_into_insufficient_space() {
+    let mut compressor = Compressor::new(6).unwrap();
+    let data = b"Hello world! This is a test string for gzip compression.";
+
+    let mut output = vec![0u8; 10]; // Intentionally too small
+    let result = compressor.compress_gzip_into(data, &mut output);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
🎯 **What:**
Added unit tests for `Compressor::compress_gzip_into` in `tests/unit_tests.rs`. This method compresses data using GZIP format into a user-provided buffer.

📊 **Coverage:**
*   **Success Case:** `test_compress_gzip_into_success` verifies that:
    *   The method returns `Ok(size)` when the buffer is large enough (calculated using `gzip_compress_bound`).
    *   The returned size is valid.
    *   The compressed data can be successfully decompressed back to the original data.
*   **Failure Case:** `test_compress_gzip_into_insufficient_space` verifies that:
    *   The method returns `Err` when the output buffer is too small to hold the compressed data.

✨ **Result:**
The test suite now explicitly covers `Compressor::compress_gzip_into`, ensuring its reliability and preventing regressions in future changes.

---
*PR created automatically by Jules for task [15043844578823167403](https://jules.google.com/task/15043844578823167403) started by @404Setup*