### PR TITLE
🧪 Add error test for compress_deflate_into and fix panic on small buffer

### DIFF
--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -149,3 +149,22 @@ fn test_compress_bound_overflow_check() {
     let bound = compressor.gzip_compress_bound(size);
     assert!(bound >= size);
 }
+
+#[test]
+fn test_compress_deflate_insufficient_space() {
+    let mut compressor = Compressor::new(6).unwrap();
+    let data = b"Hello world! This is a test string for deflate compression.";
+
+    // Create an output buffer that is too small for the compressed data
+    let mut output = vec![0u8; 5];
+
+    let result = compressor.compress_deflate_into(data, &mut output);
+
+    match result {
+        Ok(_) => panic!("Expected compression to fail due to insufficient space"),
+        Err(e) => {
+            assert_eq!(e.kind(), std::io::ErrorKind::Other);
+            assert_eq!(e.to_string(), "Insufficient space");
+        }
+    }
+}


### PR DESCRIPTION
- Added `test_compress_deflate_insufficient_space` to `tests/unit_tests.rs` to verify error handling when the output buffer is too small.
- Fixed a bug in `src/compress/mod.rs` where bitstream write failures were ignored, leading to buffer overflows and panics. Updated `write_literal`, `write_match`, `write_sym`, and `write_dynamic_huffman_header_impl` to propagate boolean success/failure results.


---
*PR created automatically by Jules for task [14769284416469570202](https://jules.google.com/task/14769284416469570202) started by @404Setup*