### PR TITLE
Add test for Compressor::new invalid level

### DIFF
--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -183,3 +183,18 @@ fn test_compress_gzip_into_insufficient_space() {
     let result = compressor.compress_gzip_into(data, &mut output);
     assert!(result.is_err());
 }
+
+#[test]
+fn test_new_compressor_invalid_level() {
+    let res = Compressor::new(-1);
+    assert!(res.is_err());
+    let err = res.err().unwrap();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(err.to_string(), "Compression level must be between 0 and 12");
+
+    let res = Compressor::new(13);
+    assert!(res.is_err());
+    let err = res.err().unwrap();
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    assert_eq!(err.to_string(), "Compression level must be between 0 and 12");
+}


### PR DESCRIPTION
Adds a unit test `test_new_compressor_invalid_level` to `tests/unit_tests.rs` to verify that `Compressor::new` returns an `InvalidInput` error when provided with compression levels outside the valid range (0-12).

This test ensures robust configuration and prevents `usize` wrapping issues in the internal implementation.

---
*PR created automatically by Jules for task [15014507534362577583](https://jules.google.com/task/15014507534362577583) started by @404Setup*