### PR TITLE
Optimize Vec capacity in DeflateEncoder output_buffers

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -50,11 +50,20 @@ impl<W: Write + Send> DeflateEncoder<W> {
             let chunks: Vec<&[u8]> = self.buffer.chunks(chunk_size).collect();
             let num_chunks = chunks.len();
 
-            while self.compressors.len() < num_chunks {
-                self.compressors.push(Compressor::new(self.level));
+            if self.compressors.len() < num_chunks {
+                self.compressors.reserve(num_chunks - self.compressors.len());
+                while self.compressors.len() < num_chunks {
+                    self.compressors.push(Compressor::new(self.level));
+                }
             }
-            while self.output_buffers.len() < num_chunks {
-                self.output_buffers.push(Vec::new());
+
+            if self.output_buffers.len() < num_chunks {
+                self.output_buffers
+                    .reserve(num_chunks - self.output_buffers.len());
+                let bound = Compressor::deflate_compress_bound(chunk_size) + 5;
+                while self.output_buffers.len() < num_chunks {
+                    self.output_buffers.push(Vec::with_capacity(bound));
+                }
             }
 
             if num_chunks == 1 {
@@ -135,7 +144,8 @@ impl<W: Write + Send> DeflateEncoder<W> {
                 self.compressors.push(Compressor::new(self.level));
             }
             if self.output_buffers.is_empty() {
-                self.output_buffers.push(Vec::new());
+                let bound = Compressor::deflate_compress_bound(self.buffer.len()) + 5;
+                self.output_buffers.push(Vec::with_capacity(bound));
             }
 
             let compressor = &mut self.compressors[0];


### PR DESCRIPTION
💡 **What:** Optimized the `DeflateEncoder` in `src/stream.rs` by pre-allocating the `compressors` and `output_buffers` vectors. Specifically, it now uses `.reserve()` to pre-allocate the outer vectors and `Vec::with_capacity(bound)` for the inner output buffers based on the calculated compression bound for each chunk.

🎯 **Why:** Previously, these vectors were grown incrementally using `push(Vec::new())`, which led to multiple dynamic memory allocations and re-allocations as the vectors grew and as the output buffers were filled during compression. Pre-allocating with a safe upper bound (`Compressor::deflate_compress_bound(chunk_size) + 5`) eliminates these reallocations in the hot path of streaming compression.

📊 **Measured Improvement:** Due to environment restrictions (missing dependencies for benchmarking in offline mode), direct performance measurements could not be obtained. However, pre-allocation is a well-established optimization that reduces the number of calls to the memory allocator and avoids expensive memory copies during vector growth.

---
*PR created automatically by Jules for task [16030239490491278635](https://jules.google.com/task/16030239490491278635) started by @404Setup*