### PR TITLE
Add edge case and success tests for `compress_zlib_into`

### DIFF
--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -183,12 +183,41 @@ fn test_compress_gzip_into_success() {
 }
 
 #[test]
+fn test_compress_zlib_into_success() {
+    let mut compressor = Compressor::new(6).unwrap();
+    let mut decompressor = Decompressor::new();
+    let data = b"Hello world! This is a test string for zlib compression into buffer.";
+
+    let bound = compressor.zlib_compress_bound(data.len());
+    let mut output = vec![0u8; bound];
+
+    let size = compressor.compress_zlib_into(data, &mut output).unwrap();
+    assert!(size > 0);
+    assert!(size <= bound);
+
+    let decompressed = decompressor
+        .decompress_zlib(&output[..size], data.len())
+        .unwrap();
+    assert_eq!(data.to_vec(), decompressed);
+}
+
+#[test]
 fn test_compress_gzip_into_insufficient_space() {
     let mut compressor = Compressor::new(6).unwrap();
     let data = b"Hello world! This is a test string for gzip compression.";
 
     let mut output = vec![0u8; 10];
     let result = compressor.compress_gzip_into(data, &mut output);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_compress_zlib_into_insufficient_space() {
+    let mut compressor = Compressor::new(6).unwrap();
+    let data = b"Hello world! This is a test string for zlib compression.";
+
+    let mut output = vec![0u8; 10];
+    let result = compressor.compress_zlib_into(data, &mut output);
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
This PR addresses a testing gap in `src/api.rs` by adding unit tests for the `compress_zlib_into` function.

🎯 **What:** The testing gap for `compress_zlib_into` has been addressed.
📊 **Coverage:** Two new test cases have been added:
  1. `test_compress_zlib_into_success`: Ensures that zlib compression into a pre-allocated buffer works correctly and produces valid data that can be decompressed.
  2. `test_compress_zlib_into_insufficient_space`: Specifically covers the edge case where the provided output buffer is too small, ensuring the function returns an error as expected.
✨ **Result:** Improved test coverage for the public API, ensuring reliability for zlib-into-buffer compression.

---
*PR created automatically by Jules for task [12067845634796540906](https://jules.google.com/task/12067845634796540906) started by @404Setup*