### PR TITLE
🧹 [code health] macroize redundant Default impls

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -130,11 +130,7 @@ pub struct Decompressor {
     limit_ratio: usize,
 }
 
-impl Default for Decompressor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_default_new!(Decompressor);
 
 impl Decompressor {
     pub fn new() -> Self {

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -41,11 +41,7 @@ impl BatchCompressor {
 
 pub struct BatchDecompressor;
 
-impl Default for BatchDecompressor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_default_new!(BatchDecompressor);
 
 impl BatchDecompressor {
     pub fn new() -> Self {

--- a/src/common.rs
+++ b/src/common.rs
@@ -84,3 +84,15 @@ pub fn slice_as_uninit_mut(slice: &mut [u8]) -> &mut [std::mem::MaybeUninit<u8>]
         )
     }
 }
+
+#[macro_export]
+macro_rules! impl_default_new {
+    ($t:ty) => {
+        impl Default for $t {
+            #[inline(always)]
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+    };
+}

--- a/src/decompress/mod.rs
+++ b/src/decompress/mod.rs
@@ -84,11 +84,7 @@ pub enum DecompressResult {
     ShortInput,
 }
 
-impl Default for Decompressor {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+crate::impl_default_new!(Decompressor);
 
 impl Decompressor {
     pub fn new() -> Self {


### PR DESCRIPTION
🎯 **What:** Introduced a shared macro `impl_default_new!` to handle the `Default` trait boilerplate and applied it to `Decompressor` and `BatchDecompressor`.
💡 **Why:** Reduces code duplication and improves maintainability by centralizing the pattern of delegating `Default::default` to `Self::new`.
✅ **Verification:** Confirmed macro correctness via standalone Rust test scripts and code review, as full crate compilation was restricted by environment constraints.
✨ **Result:** Removed redundant code across three files, replaced by clear macro calls.

---
*PR created automatically by Jules for task [16263648469470424942](https://jules.google.com/task/16263648469470424942) started by @404Setup*