### PR TITLE
🔒 fix potential panic when match finder is missing

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -91,6 +91,7 @@ impl Compressor {
                 Ok(output)
             }
             CompressResult::InsufficientSpace => Err(io::Error::other("Insufficient space")),
+            CompressResult::InternalError => Err(io::Error::other("Compression failed")),
         }
     }
 
@@ -116,10 +117,9 @@ impl Compressor {
         }
         let out_uninit = crate::common::slice_as_uninit_mut(output);
         let (res, size) = f(&mut self.inner, data, out_uninit);
-        if res == CompressResult::Success {
-            Ok(size)
-        } else {
-            Err(io::Error::other(error_msg))
+        match res {
+            CompressResult::Success => Ok(size),
+            _ => Err(io::Error::other(error_msg)),
         }
     }
 }

--- a/src/compress/mod.rs
+++ b/src/compress/mod.rs
@@ -210,6 +210,7 @@ fn compute_static_tables() -> StaticTables {
 pub enum CompressResult {
     Success,
     InsufficientSpace,
+    InternalError,
 }
 
 #[derive(Clone, Copy)]
@@ -740,7 +741,10 @@ impl Compressor {
 
         let mut bs = Bitstream::new(output);
 
-        let mut mf_enum = self.mf.take().unwrap();
+        let mut mf_enum = match self.mf.take() {
+            Some(mf) => mf,
+            None => return (CompressResult::InternalError, 0, 0),
+        };
 
         let res = match &mut mf_enum {
             MatchFinderEnum::Chain(mf) => self.compress_loop(mf, input, &mut bs, flush_mode),
@@ -1030,7 +1034,7 @@ impl Compressor {
         (processed, bits)
     }
 
-    pub fn compress_to_size(&mut self, input: &[u8], final_block: bool) -> usize {
+    pub fn compress_to_size(&mut self, input: &[u8], final_block: bool) -> (CompressResult, usize) {
         if self.compression_level == 0 {
             let num_blocks = input.len() / 65535
                 + if !input.len().is_multiple_of(65535) || (input.is_empty() && final_block) {
@@ -1038,10 +1042,13 @@ impl Compressor {
                 } else {
                     0
                 };
-            return input.len() + num_blocks * 5;
+            return (CompressResult::Success, input.len() + num_blocks * 5);
         }
 
-        let mut mf_enum = self.mf.take().unwrap();
+        let mut mf_enum = match self.mf.take() {
+            Some(mf) => mf,
+            None => return (CompressResult::InternalError, 0),
+        };
 
         let res = match &mut mf_enum {
             MatchFinderEnum::Chain(mf) => self.compress_to_size_loop(mf, input, final_block),
@@ -1050,7 +1057,7 @@ impl Compressor {
         };
 
         self.mf = Some(mf_enum);
-        res
+        (CompressResult::Success, res)
     }
 
     fn accumulate_greedy_frequencies<T: MatchFinderTrait>(
@@ -2405,5 +2412,25 @@ impl Compressor {
         }
         out_idx += 4;
         (CompressResult::Success, out_idx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compressor_missing_mf() {
+        let mut compressor = Compressor::new(6);
+        compressor.mf = None;
+
+        let input = b"hello world";
+        let mut output = [MaybeUninit::uninit(); 100];
+
+        let (res, _, _) = compressor.compress(input, &mut output, FlushMode::Finish);
+        assert_eq!(res, CompressResult::InternalError);
+
+        let (res, _) = compressor.compress_to_size(input, true);
+        assert_eq!(res, CompressResult::InternalError);
     }
 }


### PR DESCRIPTION
🎯 **What:** Fixed potential panics in `Compressor::compress` and `Compressor::compress_to_size` caused by calling `.unwrap()` on a missing match finder.
⚠️ **Risk:** A Denial of Service (DoS) vulnerability where an attacker could trigger a crash if they can induce a state where the match finder is `None` (e.g., by reusing a `Compressor` instance after a previous operation panicked).
🛡️ **Solution:** Introduced a `CompressResult::InternalError` variant and replaced `.unwrap()` with safe pattern matching. Updated the public API to propagate these errors as `std::io::Error`. Added a regression test `test_compressor_missing_mf`.

---
*PR created automatically by Jules for task [17842979915340093213](https://jules.google.com/task/17842979915340093213) started by @404Setup*