### PR TITLE
🔒 [security fix] Fix buffer length manipulation without initialization

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -26,6 +26,7 @@ impl BatchCompressor {
                     let (res, size, _) =
                         compressor.compress(input, buf_slice, crate::compress::FlushMode::Finish);
                     if res == CompressResult::Success {
+                        assert!(size <= bound);
                         unsafe {
                             buffer.set_len(size);
                         }
@@ -63,16 +64,20 @@ impl BatchDecompressor {
             .map_init(
                 || (Decompressor::new(), Vec::new()),
                 |(decompressor, buffer), (&input, &max_size)| {
+                    buffer.clear();
                     if buffer.capacity() < max_size {
-                        buffer.reserve(max_size.saturating_sub(buffer.len()));
+                        buffer.reserve(max_size);
                     }
-                    unsafe {
-                        buffer.set_len(max_size);
-                    }
+                    let buf_uninit = buffer.spare_capacity_mut();
+                    let buf_slice = &mut buf_uninit[..max_size];
 
-                    let (res, _, size) = decompressor.decompress(input, buffer);
+                    let (res, _, size) = unsafe { decompressor.decompress_uninit(input, buf_slice) };
                     if res == DecompressResult::Success {
-                        Some(buffer[..size].to_vec())
+                        assert!(size <= max_size);
+                        unsafe {
+                            buffer.set_len(size);
+                        }
+                        Some(buffer.to_vec())
                     } else {
                         None
                     }

--- a/src/compress/mod.rs
+++ b/src/compress/mod.rs
@@ -683,17 +683,17 @@ impl Compressor {
                         let mode = if is_last { flush_mode } else { FlushMode::Sync };
 
                         let bound = Self::deflate_compress_bound(chunk.len());
+                        buf.clear();
                         if buf.capacity() < bound {
-                            buf.reserve(bound - buf.len());
-                        }
-                        unsafe {
-                            buf.set_len(bound);
+                            buf.reserve(bound);
                         }
 
-                        let buf_uninit = slice_as_uninit_mut(buf);
+                        let buf_uninit = buf.spare_capacity_mut();
+                        let buf_uninit = &mut buf_uninit[..bound];
 
                         let (res, size, _) = compressor.compress(chunk, buf_uninit, mode);
                         if res == CompressResult::Success {
+                            assert!(size <= bound);
                             unsafe {
                                 buf.set_len(size);
                             }
@@ -920,12 +920,7 @@ impl Compressor {
         self.dp_costs[0] = 0;
 
         self.dp_path.clear();
-        if self.dp_path.capacity() < processed + 1 {
-            self.dp_path.reserve(processed + 1 - self.dp_path.len());
-        }
-        unsafe {
-            self.dp_path.set_len(processed + 1);
-        }
+        self.dp_path.resize(processed + 1, 0);
 
         mf.reset();
         let mut pos = 0;
@@ -1717,12 +1712,7 @@ impl Compressor {
         self.dp_costs[0] = 0;
 
         self.dp_path.clear();
-        if self.dp_path.capacity() < processed + 1 {
-            self.dp_path.reserve(processed + 1 - self.dp_path.len());
-        }
-        unsafe {
-            self.dp_path.set_len(processed + 1);
-        }
+        self.dp_path.resize(processed + 1, 0);
 
         mf.reset();
         let mut pos = 0;

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -74,13 +74,11 @@ impl<W: Write + Send> DeflateEncoder<W> {
                 if !final_block {
                     bound += 5;
                 }
-                if output.len() < bound {
+                output.clear();
+                if output.capacity() < bound {
                     output
-                        .try_reserve(bound - output.len())
+                        .try_reserve(bound)
                         .map_err(io::Error::other)?;
-                    unsafe {
-                        output.set_len(bound);
-                    }
                 }
 
                 let mode = if final_block {
@@ -88,9 +86,14 @@ impl<W: Write + Send> DeflateEncoder<W> {
                 } else {
                     crate::compress::FlushMode::Sync
                 };
-                let out_uninit = crate::common::slice_as_uninit_mut(output);
+                let out_uninit = output.spare_capacity_mut();
+                let out_uninit = &mut out_uninit[..bound];
                 let (res, size, _) = compressor.compress(chunk, out_uninit, mode);
                 if res == CompressResult::Success {
+                    assert!(size <= bound);
+                    unsafe {
+                        output.set_len(size);
+                    }
                     if let Some(writer) = &mut self.writer {
                         writer.write_all(&output[..size])?;
                     }
@@ -108,13 +111,11 @@ impl<W: Write + Send> DeflateEncoder<W> {
                         if !(final_block && i == num_chunks - 1) {
                             bound += 5;
                         }
-                        if output.len() < bound {
+                        output.clear();
+                        if output.capacity() < bound {
                             output
-                                .try_reserve(bound - output.len())
+                                .try_reserve(bound)
                                 .map_err(io::Error::other)?;
-                            unsafe {
-                                output.set_len(bound);
-                            }
                         }
 
                         let mode = if final_block && i == num_chunks - 1 {
@@ -122,9 +123,14 @@ impl<W: Write + Send> DeflateEncoder<W> {
                         } else {
                             crate::compress::FlushMode::Sync
                         };
-                        let out_uninit = crate::common::slice_as_uninit_mut(output);
+                        let out_uninit = output.spare_capacity_mut();
+                        let out_uninit = &mut out_uninit[..bound];
                         let (res, size, _) = compressor.compress(chunk, out_uninit, mode);
                         if res == CompressResult::Success {
+                            assert!(size <= bound);
+                            unsafe {
+                                output.set_len(size);
+                            }
                             Ok(size)
                         } else {
                             Err(io::Error::other("Compression failed"))
@@ -154,13 +160,11 @@ impl<W: Write + Send> DeflateEncoder<W> {
             if !final_block {
                 bound += 5;
             }
-            if output.len() < bound {
+            output.clear();
+            if output.capacity() < bound {
                 output
-                    .try_reserve(bound - output.len())
+                    .try_reserve(bound)
                     .map_err(io::Error::other)?;
-                unsafe {
-                    output.set_len(bound);
-                }
             }
 
             let mode = if final_block {
@@ -168,9 +172,14 @@ impl<W: Write + Send> DeflateEncoder<W> {
             } else {
                 crate::compress::FlushMode::Sync
             };
-            let out_uninit = crate::common::slice_as_uninit_mut(output);
+            let out_uninit = output.spare_capacity_mut();
+            let out_uninit = &mut out_uninit[..bound];
             let (res, size, _) = compressor.compress(&self.buffer, out_uninit, mode);
             if res == CompressResult::Success {
+                assert!(size <= bound);
+                unsafe {
+                    output.set_len(size);
+                }
                 if let Some(writer) = &mut self.writer {
                     writer.write_all(&output[..size])?;
                 }


### PR DESCRIPTION
🎯 **What:** Fixed a security vulnerability involving the unsafe use of `set_len` on uninitialized `Vec` buffers in `src/batch.rs`, `src/stream.rs`, and `src/compress/mod.rs`.

⚠️ **Risk:** Using `set_len` to extend a vector before the data is actually written leaves uninitialized memory exposed. This can lead to Undefined Behavior (UB) or sensitive information leakage if the subsequent operation fails or writes fewer bytes than expected.

🛡️ **Solution:**
- Replaced the "reserve + set_len + write" pattern with "clear + reserve + write into spare_capacity_mut + set_len".
- Utilized `spare_capacity_mut()` to safely handle uninitialized memory slices as `MaybeUninit<u8>`.
- Added `assert!(size <= bound)` before calling `set_len` to ensure that the actual bytes written do not exceed the allocated capacity.
- Replaced dangerous manual `set_len` calls in dynamic programming logic with safe `resize(..., 0)` to guarantee zero-initialization.
- Migrated `BatchDecompressor` to use `decompress_uninit` for direct writing into uninitialized buffers.

---
*PR created automatically by Jules for task [12893776821588517495](https://jules.google.com/task/12893776821588517495) started by @404Setup*