### PR TITLE
⚡ optimize: use slice fill for code length repetitions in decompressor

### DIFF
--- a/src/decompress/mod.rs
+++ b/src/decompress/mod.rs
@@ -462,12 +462,9 @@ impl Decompressor {
                 let rep_count = 3 + ((self.bitbuf & 3) as usize);
                 self.bitbuf >>= 2;
                 self.bitsleft -= 2;
-                for _ in 0..rep_count {
-                    if i < total_syms {
-                        self.lens[i] = rep_val;
-                        i += 1;
-                    }
-                }
+                let fill_len = min(rep_count, total_syms - i);
+                self.lens[i..i + fill_len].fill(rep_val);
+                i += fill_len;
             } else if presym == 17 {
                 if self.bitsleft < 3 {
                     return DecompressResult::ShortInput;
@@ -475,12 +472,9 @@ impl Decompressor {
                 let rep_count = 3 + ((self.bitbuf & 7) as usize);
                 self.bitbuf >>= 3;
                 self.bitsleft -= 3;
-                for _ in 0..rep_count {
-                    if i < total_syms {
-                        self.lens[i] = 0;
-                        i += 1;
-                    }
-                }
+                let fill_len = min(rep_count, total_syms - i);
+                self.lens[i..i + fill_len].fill(0);
+                i += fill_len;
             } else {
                 if self.bitsleft < 7 {
                     return DecompressResult::ShortInput;
@@ -488,12 +482,9 @@ impl Decompressor {
                 let rep_count = 11 + ((self.bitbuf & 0x7F) as usize);
                 self.bitbuf >>= 7;
                 self.bitsleft -= 7;
-                for _ in 0..rep_count {
-                    if i < total_syms {
-                        self.lens[i] = 0;
-                        i += 1;
-                    }
-                }
+                let fill_len = min(rep_count, total_syms - i);
+                self.lens[i..i + fill_len].fill(0);
+                i += fill_len;
             }
         }
         if i != total_syms {


### PR DESCRIPTION
Optimized the Huffman code length decoding in `read_dynamic_huffman_header` by replacing manual repetition loops with slice `fill`. This reduces overhead by eliminating per-element bounds checks and enabling potentially faster block memory operations. Memory safety and original functional behavior are preserved through careful bounds clamping with `min(rep_count, total_syms - i)`.

---
*PR created automatically by Jules for task [9104853597736516714](https://jules.google.com/task/9104853597736516714) started by @404Setup*