### PR TITLE
🧹 [code health] Replace unsafe unwrap in DeflateEncoder::finish

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -199,7 +199,9 @@ impl<W: Write + Send> DeflateEncoder<W> {
     /// but will silently ignore any errors.
     pub fn finish(mut self) -> io::Result<W> {
         self.flush_buffer(true)?;
-        Ok(self.writer.take().unwrap())
+        self.writer
+            .take()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "encoder already finished"))
     }
 }
 


### PR DESCRIPTION
🎯 **What:** Replaced an unsafe `.unwrap()` call in `DeflateEncoder::finish` with proper error handling using `.ok_or_else()`.
💡 **Why:** To improve maintainability and prevent potential panics if `finish` is called in an unexpected state. It now returns a descriptive `std::io::Error`.
✅ **Verification:** Verified by checking the file content and running a minimal syntax check for the modified code in an environment with restricted dependencies.
✨ **Result:** Improved code health and safety in the streaming encoder implementation.

---
*PR created automatically by Jules for task [4601097661000071630](https://jules.google.com/task/4601097661000071630) started by @404Setup*