### PR TITLE
🔒 [security fix] Unsafe set_len without size validation in api.rs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -85,6 +85,7 @@ impl Compressor {
         let (res, size) = f(&mut self.inner, data, out_uninit);
         match res {
             CompressResult::Success => {
+                assert!(size <= bound);
                 unsafe {
                     output.set_len(size);
                 }
@@ -118,7 +119,10 @@ impl Compressor {
         let out_uninit = crate::common::slice_as_uninit_mut(output);
         let (res, size) = f(&mut self.inner, data, out_uninit);
         match res {
-            CompressResult::Success => Ok(size),
+            CompressResult::Success => {
+                assert!(size <= output.len());
+                Ok(size)
+            }
             _ => Err(io::Error::other(error_msg)),
         }
     }
@@ -233,6 +237,7 @@ impl Decompressor {
 
         let (res, _, size) = f(&mut self.inner, data, out_uninit);
         if res == crate::decompress::DecompressResult::Success {
+            assert!(size <= expected_size);
             unsafe {
                 output.set_len(size);
             }
@@ -268,6 +273,7 @@ impl Decompressor {
         let out_uninit = crate::common::slice_as_uninit_mut(output);
         let (res, _, size) = f(&mut self.inner, data, out_uninit);
         if res == crate::decompress::DecompressResult::Success {
+            assert!(size <= output.len());
             Ok(size)
         } else {
             Err(io::Error::new(


### PR DESCRIPTION
🎯 **What:** Added `assert!` statements to validate that the returned size from compression and decompression operations does not exceed the allocated capacity or buffer length before calling `set_len` or returning the size.
⚠️ **Risk:** Calling `set_len` with a size greater than the vector's capacity is undefined behavior in Rust, which could lead to memory corruption or out-of-bounds access.
🛡️ **Solution:** Implemented explicit bounds checks using `assert!(size <= bound)` and `assert!(size <= output.len())` in `compress_helper`, `decompress_helper`, `compress_into_helper`, and `decompress_into_helper` within `src/api.rs`.

---
*PR created automatically by Jules for task [1440824756357674605](https://jules.google.com/task/1440824756357674605) started by @404Setup*