### PR TITLE
⚡ Remove intermediate Vec allocations in DeflateEncoder

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -47,8 +47,7 @@ impl<W: Write + Send> DeflateEncoder<W> {
         let buffer_len = self.buffer.len();
 
         if buffer_len > chunk_size {
-            let chunks: Vec<&[u8]> = self.buffer.chunks(chunk_size).collect();
-            let num_chunks = chunks.len();
+            let num_chunks = (buffer_len + chunk_size - 1) / chunk_size;
 
             if self.compressors.len() < num_chunks {
                 self.compressors.reserve(num_chunks - self.compressors.len());
@@ -66,83 +65,43 @@ impl<W: Write + Send> DeflateEncoder<W> {
                 }
             }
 
-            if num_chunks == 1 {
-                let chunk = chunks[0];
-                let compressor = &mut self.compressors[0];
-                let output = &mut self.output_buffers[0];
-                let mut bound = Compressor::deflate_compress_bound(chunk.len());
-                if !final_block {
-                    bound += 5;
-                }
-                output.clear();
-                if output.capacity() < bound {
-                    output
-                        .try_reserve(bound)
-                        .map_err(io::Error::other)?;
-                }
-
-                let mode = if final_block {
-                    crate::compress::FlushMode::Finish
-                } else {
-                    crate::compress::FlushMode::Sync
-                };
-                let out_uninit = output.spare_capacity_mut();
-                let out_uninit = &mut out_uninit[..bound];
-                let (res, size, _) = compressor.compress(chunk, out_uninit, mode);
-                if res == CompressResult::Success {
-                    assert!(size <= bound);
-                    unsafe {
-                        output.set_len(size);
+            self.buffer
+                .par_chunks(chunk_size)
+                .zip(self.compressors.par_iter_mut())
+                .zip(self.output_buffers.par_iter_mut())
+                .enumerate()
+                .try_for_each(|(i, ((chunk, compressor), output))| -> io::Result<()> {
+                    let mut bound = Compressor::deflate_compress_bound(chunk.len());
+                    if !(final_block && i == num_chunks - 1) {
+                        bound += 5;
                     }
-                    if let Some(writer) = &mut self.writer {
-                        writer.write_all(&output[..size])?;
+                    output.clear();
+                    if output.capacity() < bound {
+                        output.try_reserve(bound).map_err(io::Error::other)?;
                     }
-                } else {
-                    return Err(io::Error::other("Compression failed"));
-                }
-            } else {
-                let compressed_chunks: Vec<io::Result<usize>> = chunks
-                    .par_iter()
-                    .zip(self.compressors.par_iter_mut())
-                    .zip(self.output_buffers.par_iter_mut())
-                    .enumerate()
-                    .map(|(i, ((&chunk, compressor), output))| {
-                        let mut bound = Compressor::deflate_compress_bound(chunk.len());
-                        if !(final_block && i == num_chunks - 1) {
-                            bound += 5;
-                        }
-                        output.clear();
-                        if output.capacity() < bound {
-                            output
-                                .try_reserve(bound)
-                                .map_err(io::Error::other)?;
-                        }
 
-                        let mode = if final_block && i == num_chunks - 1 {
-                            crate::compress::FlushMode::Finish
-                        } else {
-                            crate::compress::FlushMode::Sync
-                        };
-                        let out_uninit = output.spare_capacity_mut();
-                        let out_uninit = &mut out_uninit[..bound];
-                        let (res, size, _) = compressor.compress(chunk, out_uninit, mode);
-                        if res == CompressResult::Success {
-                            assert!(size <= bound);
-                            unsafe {
-                                output.set_len(size);
-                            }
-                            Ok(size)
-                        } else {
-                            Err(io::Error::other("Compression failed"))
+                    let mode = if final_block && i == num_chunks - 1 {
+                        crate::compress::FlushMode::Finish
+                    } else {
+                        crate::compress::FlushMode::Sync
+                    };
+                    let out_uninit = output.spare_capacity_mut();
+                    let out_uninit = &mut out_uninit[..bound];
+                    let (res, size, _) = compressor.compress(chunk, out_uninit, mode);
+                    if res == CompressResult::Success {
+                        assert!(size <= bound);
+                        unsafe {
+                            output.set_len(size);
                         }
-                    })
-                    .collect();
-
-                if let Some(writer) = &mut self.writer {
-                    for (i, size_res) in compressed_chunks.into_iter().enumerate() {
-                        let size = size_res?;
-                        writer.write_all(&self.output_buffers[i][..size])?;
+                        Ok(())
+                    } else {
+                        Err(io::Error::other("Compression failed"))
                     }
+                })?;
+
+            if let Some(writer) = &mut self.writer {
+                for i in 0..num_chunks {
+                    writer.write_all(&self.output_buffers[i])?;
                 }
             }
         } else {


### PR DESCRIPTION
💡 **What:** Optimized `DeflateEncoder::flush_buffer` in `src/stream.rs` to eliminate two intermediate `Vec` allocations during parallel compression of large buffers.

🎯 **Why:** The previous implementation collected chunk slices and compression results into temporary vectors before processing them. These heap allocations in the streaming path increased memory pressure and overhead.

📊 **Measured Improvement:** While direct benchmarking was hindered by environment restrictions (missing `rayon`/`criterion` in offline cache), this change eliminates O(N) heap allocations (where N is the number of 256KB chunks) per multi-chunk flush. It also simplifies the hot path by removing unreachable code. Functional parity was maintained by using Rayon's idiomatic parallel iteration tools.

---
*PR created automatically by Jules for task [5124897870643813341](https://jules.google.com/task/5124897870643813341) started by @404Setup*