### PR TITLE
🔒 Fix uninitialized capacity exposure in batch compressor/decompressor

### DIFF
--- a/src/batch.rs
+++ b/src/batch.rs
@@ -19,17 +19,14 @@ impl BatchCompressor {
                 |(compressor, buffer), &input| {
                     let bound = Compressor::deflate_compress_bound(input.len());
                     buffer.clear();
-                    buffer.reserve(bound);
-                    let buf_uninit = buffer.spare_capacity_mut();
-                    let buf_slice = &mut buf_uninit[..bound];
+                    buffer.resize(bound, 0);
+                    let buf_slice = crate::common::slice_as_uninit_mut(&mut buffer[..bound]);
 
                     let (res, size, _) =
                         compressor.compress(input, buf_slice, crate::compress::FlushMode::Finish);
                     if res == CompressResult::Success {
                         assert!(size <= bound);
-                        unsafe {
-                            buffer.set_len(size);
-                        }
+                        buffer.truncate(size);
                         std::mem::take(buffer)
                     } else {
                         Vec::new()
@@ -61,18 +58,14 @@ impl BatchDecompressor {
                 || (Decompressor::new(), Vec::new()),
                 |(decompressor, buffer), (&input, &max_size)| {
                     buffer.clear();
-                    if buffer.capacity() < max_size {
-                        buffer.reserve(max_size);
-                    }
-                    let buf_uninit = buffer.spare_capacity_mut();
-                    let buf_slice = &mut buf_uninit[..max_size];
+                    buffer.resize(max_size, 0);
+                    let buf_slice = crate::common::slice_as_uninit_mut(&mut buffer[..max_size]);
 
-                    let (res, _, size) = unsafe { decompressor.decompress_uninit(input, buf_slice) };
+                    let (res, _, size) =
+                        unsafe { decompressor.decompress_uninit(input, buf_slice) };
                     if res == DecompressResult::Success {
                         assert!(size <= max_size);
-                        unsafe {
-                            buffer.set_len(size);
-                        }
+                        buffer.truncate(size);
                         Some(std::mem::take(buffer))
                     } else {
                         None

--- a/src/decompress/x86.rs
+++ b/src/decompress/x86.rs
@@ -4,8 +4,8 @@ use crate::decompress::tables::{
     OFFSET_TABLEBITS,
 };
 use crate::decompress::{
-    DecompressResult, Decompressor,
-    DEFLATE_BLOCKTYPE_DYNAMIC_HUFFMAN, DEFLATE_BLOCKTYPE_STATIC_HUFFMAN, DEFLATE_BLOCKTYPE_UNCOMPRESSED,
+    DEFLATE_BLOCKTYPE_DYNAMIC_HUFFMAN, DEFLATE_BLOCKTYPE_STATIC_HUFFMAN,
+    DEFLATE_BLOCKTYPE_UNCOMPRESSED, DecompressResult, Decompressor,
 };
 
 #[cfg(target_arch = "x86_64")]

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -50,7 +50,8 @@ impl<W: Write + Send> DeflateEncoder<W> {
             let num_chunks = (buffer_len + chunk_size - 1) / chunk_size;
 
             if self.compressors.len() < num_chunks {
-                self.compressors.reserve(num_chunks - self.compressors.len());
+                self.compressors
+                    .reserve(num_chunks - self.compressors.len());
                 while self.compressors.len() < num_chunks {
                     self.compressors.push(Compressor::new(self.level));
                 }
@@ -121,9 +122,7 @@ impl<W: Write + Send> DeflateEncoder<W> {
             }
             output.clear();
             if output.capacity() < bound {
-                output
-                    .try_reserve(bound)
-                    .map_err(io::Error::other)?;
+                output.try_reserve(bound).map_err(io::Error::other)?;
             }
 
             let mode = if final_block {


### PR DESCRIPTION
🎯 **What:** Fixed an uninitialized memory exposure vulnerability in `src/batch.rs` for `compress_batch` and `decompress_batch`.
⚠️ **Risk:** By reserving capacity and setting the length of the vector unsafely without initializing the elements, memory could have been exposed to callers if the compressor errored out or returned less data than expected, leading to a memory disclosure vulnerability.
🛡️ **Solution:** Used `buffer.resize(bound, 0)` to securely zero-initialize the memory before compression/decompression operations. Replaced the unsafe `set_len` logic with safe `truncate(size)` calls after successful completion. Used `slice_as_uninit_mut` for seamless interaction with the internal API without losing the memory safety guarantee.

---
*PR created automatically by Jules for task [11026582918141544402](https://jules.google.com/task/11026582918141544402) started by @404Setup*