### PR TITLE
🔒 Prevent uninitialized memory exposure via unsafe set_len() in output buffers

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -79,16 +79,14 @@ impl Compressor {
         let mut output = Vec::new();
         output.try_reserve_exact(bound).map_err(io::Error::other)?;
 
-        let out_uninit = output.spare_capacity_mut();
-        let out_uninit = &mut out_uninit[..bound];
+        output.resize(bound, 0);
+        let out_uninit = crate::common::slice_as_uninit_mut(&mut output[..bound]);
 
         let (res, size) = f(&mut self.inner, data, out_uninit);
         match res {
             CompressResult::Success => {
                 assert!(size <= bound);
-                unsafe {
-                    output.set_len(size);
-                }
+                output.truncate(size);
                 Ok(output)
             }
             CompressResult::InsufficientSpace => Err(io::Error::other("Insufficient space")),
@@ -232,15 +230,13 @@ impl Decompressor {
             .try_reserve_exact(expected_size)
             .map_err(io::Error::other)?;
 
-        let out_uninit = output.spare_capacity_mut();
-        let out_uninit = &mut out_uninit[..expected_size];
+        output.resize(expected_size, 0);
+        let out_uninit = crate::common::slice_as_uninit_mut(&mut output[..expected_size]);
 
         let (res, _, size) = f(&mut self.inner, data, out_uninit);
         if res == crate::decompress::DecompressResult::Success {
             assert!(size <= expected_size);
-            unsafe {
-                output.set_len(size);
-            }
+            output.truncate(size);
             Ok(output)
         } else {
             Err(io::Error::new(

--- a/src/compress/mod.rs
+++ b/src/compress/mod.rs
@@ -689,15 +689,13 @@ impl Compressor {
                             buf.reserve(bound);
                         }
 
-                        let buf_uninit = buf.spare_capacity_mut();
-                        let buf_uninit = &mut buf_uninit[..bound];
+                        buf.resize(bound, 0);
+                        let buf_uninit = crate::common::slice_as_uninit_mut(&mut buf[..bound]);
 
                         let (res, size, _) = compressor.compress(chunk, buf_uninit, mode);
                         if res == CompressResult::Success {
                             assert!(size <= bound);
-                            unsafe {
-                                buf.set_len(size);
-                            }
+                            buf.truncate(size);
                             if size < buf.capacity() / 2 {
                                 Ok(buf.to_vec())
                             } else {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -86,14 +86,12 @@ impl<W: Write + Send> DeflateEncoder<W> {
                     } else {
                         crate::compress::FlushMode::Sync
                     };
-                    let out_uninit = output.spare_capacity_mut();
-                    let out_uninit = &mut out_uninit[..bound];
+                    output.resize(bound, 0);
+                    let out_uninit = crate::common::slice_as_uninit_mut(&mut output[..bound]);
                     let (res, size, _) = compressor.compress(chunk, out_uninit, mode);
                     if res == CompressResult::Success {
                         assert!(size <= bound);
-                        unsafe {
-                            output.set_len(size);
-                        }
+                        output.truncate(size);
                         Ok(())
                     } else {
                         Err(io::Error::other("Compression failed"))
@@ -130,14 +128,12 @@ impl<W: Write + Send> DeflateEncoder<W> {
             } else {
                 crate::compress::FlushMode::Sync
             };
-            let out_uninit = output.spare_capacity_mut();
-            let out_uninit = &mut out_uninit[..bound];
+            output.resize(bound, 0);
+            let out_uninit = crate::common::slice_as_uninit_mut(&mut output[..bound]);
             let (res, size, _) = compressor.compress(&self.buffer, out_uninit, mode);
             if res == CompressResult::Success {
                 assert!(size <= bound);
-                unsafe {
-                    output.set_len(size);
-                }
+                output.truncate(size);
                 if let Some(writer) = &mut self.writer {
                     writer.write_all(&output[..size])?;
                 }


### PR DESCRIPTION
🎯 **What:** 
Fixed a vulnerability in multiple API entry points and internal handlers (`api.rs`, `stream.rs`, `compress/mod.rs`) where memory was allocated but not initialized before passing it to FFI-like boundaries via `spare_capacity_mut` and finalized with an unsafe `set_len()`.

⚠️ **Risk:** 
If an internal logic error or boundary overflow inside the underlying `compress()` or `decompress()` routines caused them to misreport the number of bytes written, `unsafe { output.set_len(size); }` would allow the program to expose or read uninitialized heap memory. This can lead to information leaks or undefined behavior.

🛡️ **Solution:** 
Replaced the pattern with safe `output.resize(bound, 0)` and `output.truncate(size)`. This guarantees that memory passed to the compressor is always zero-initialized, preventing data leaks. The `truncate` safely guarantees the buffer len does not exceed the valid bounds. Applied consistently across all affected buffer allocation paths in the crate.

---
*PR created automatically by Jules for task [17696576799208669327](https://jules.google.com/task/17696576799208669327) started by @404Setup*