### PR TITLE
🧪 Add edge case and property tests for bsr32

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -116,6 +116,25 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn test_bsr32_zero() {
+        let _ = bsr32(0);
+    }
+
+    #[test]
+    fn test_bsr32_property_all_powers_of_two() {
+        for i in 0..32 {
+            let val = 1u32 << i;
+            assert_eq!(bsr32(val), i as u32);
+
+            if i < 31 {
+                let mask = (1u32 << (i + 1)) - 1;
+                assert_eq!(bsr32(mask), i as u32);
+            }
+        }
+    }
+
+    #[test]
     fn test_slice_as_uninit_mut() {
         let mut data = [1u8, 2, 3, 4, 5];
         let uninit_slice = slice_as_uninit_mut(&mut data);


### PR DESCRIPTION
🎯 **What:** Improved test coverage for `bsr32` (Bit Scan Reverse) in `src/common.rs`.
📊 **Coverage:** Now tests what happens on underflow (`bsr32(0)`) and comprehensively checks every single power of 2 and bit mask boundary.
✨ **Result:** Better confidence during future refactoring of bit operations in the decompressor/compressor without regressions.

---
*PR created automatically by Jules for task [16539438203784638562](https://jules.google.com/task/16539438203784638562) started by @404Setup*