### PR TITLE
fix: prevent 32-bit SIMD lane overflow during scalar reduction in adler32 optimizations

### DIFF
--- a/src/adler32/x86.rs
+++ b/src/adler32/x86.rs
@@ -530,22 +530,13 @@ pub unsafe fn adler32_x86_avx2(adler: u32, p: &[u8]) -> u32 {
 
         v_s2 = _mm256_add_epi32(v_s2, v_s1_sums);
 
-        let v_s1_128 = _mm_add_epi32(
-            _mm256_extracti128_si256(v_s1, 0),
-            _mm256_extracti128_si256(v_s1, 1),
-        );
-        let v_s2_128 = _mm_add_epi32(
-            _mm256_extracti128_si256(v_s2, 0),
-            _mm256_extracti128_si256(v_s2, 1),
-        );
+        let mut s1_buf = [0u32; 8];
+        let mut s2_buf = [0u32; 8];
+        _mm256_storeu_si256(s1_buf.as_mut_ptr() as *mut __m256i, v_s1);
+        _mm256_storeu_si256(s2_buf.as_mut_ptr() as *mut __m256i, v_s2);
 
-        let mut s1_buf = [0u32; 4];
-        let mut s2_buf = [0u32; 4];
-        _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
-        _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
-
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64) as u32;
-        let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64 + s1_buf[4] as u64 + s1_buf[6] as u64) as u32;
+        let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64 + s2_buf[4] as u64 + s2_buf[5] as u64 + s2_buf[6] as u64 + s2_buf[7] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
         s1 %= DIVISOR;
@@ -819,7 +810,7 @@ pub unsafe fn adler32_x86_avx2_vnni(adler: u32, p: &[u8]) -> u32 {
         _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
         _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64) as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64) as u32;
         let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
@@ -1079,7 +1070,7 @@ pub unsafe fn adler32_x86_avx512_vnni(adler: u32, p: &[u8]) -> u32 {
         _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
         _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64) as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64) as u32;
         let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 

--- a/src/adler32/x86.rs
+++ b/src/adler32/x86.rs
@@ -256,8 +256,9 @@ pub unsafe fn adler32_x86_sse2(adler: u32, p: &[u8]) -> u32 {
     if data.len() >= 16 {
         let d = _mm_loadu_si128(data.as_ptr() as *const __m128i);
         let sad = _mm_sad_epu8(d, v_zero);
-        let sum_s1 =
-            (_mm_cvtsi128_si32(_mm_add_epi32(sad, _mm_srli_si128(sad, 8))) as u32) as u64 as u32;
+        let mut buf = [0u32; 4];
+        _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, sad);
+        let sum_s1 = (buf[0] as u64 + buf[2] as u64) as u32;
         s2 = ((s2 as u64 + s1 as u64 * 16) % DIVISOR as u64) as u32;
         s1 = (s1 as u64 + sum_s1 as u64) as u32;
 
@@ -272,8 +273,9 @@ pub unsafe fn adler32_x86_sse2(adler: u32, p: &[u8]) -> u32 {
         let s = _mm_add_epi32(s_lo, s_hi);
 
         let s_step = _mm_add_epi32(s, _mm_srli_si128(s, 8));
-        let sum_s2 = (_mm_cvtsi128_si32(_mm_add_epi32(s_step, _mm_srli_si128(s_step, 4))) as u32)
-            as u64 as u32;
+        let mut buf = [0u32; 4];
+        _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, s_step);
+        let sum_s2 = (buf[0] as u64 + buf[1] as u64) as u32;
         s2 = ((s2 as u64 + sum_s2 as u64) % DIVISOR as u64) as u32;
 
         data = &data[16..];
@@ -556,8 +558,9 @@ pub unsafe fn adler32_x86_avx2(adler: u32, p: &[u8]) -> u32 {
         let v_zero_xmm = _mm_setzero_si128();
 
         let sad = _mm_sad_epu8(d, v_zero_xmm);
-        let s1_part = (_mm_cvtsi128_si32(_mm_add_epi32(sad, _mm_unpackhi_epi64(sad, sad))) as u32)
-            as u64 as u32;
+        let mut buf = [0u32; 4];
+        _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, sad);
+        let s1_part = (buf[0] as u64 + buf[2] as u64) as u32;
 
         s2 = ((s2 as u64 + s1 as u64 * 16) % DIVISOR as u64) as u32;
         s1 = (s1 as u64 + s1_part as u64) as u32;
@@ -568,8 +571,9 @@ pub unsafe fn adler32_x86_avx2(adler: u32, p: &[u8]) -> u32 {
 
         let s_sum = _mm_add_epi32(s, _mm_shuffle_epi32(s, 0x4E));
         let s_sum = _mm_add_epi32(s_sum, _mm_shuffle_epi32(s_sum, 0xB1));
+        _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, s_sum);
 
-        s2 = ((s2 as u64 + (_mm_cvtsi128_si32(s_sum) as u32) as u64) % DIVISOR as u64) as u32;
+        s2 = ((s2 as u64 + buf[0] as u64) % DIVISOR as u64) as u32;
 
         ptr = ptr.add(16);
         len -= 16;
@@ -811,14 +815,15 @@ pub unsafe fn adler32_x86_avx2_vnni(adler: u32, p: &[u8]) -> u32 {
             _mm256_extracti128_si256(v_s2, 1),
         );
 
-        let v_s1_sum = _mm_add_epi32(v_s1_128, _mm_shuffle_epi32(v_s1_128, 0x31));
-        let v_s1_sum = _mm_add_epi32(v_s1_sum, _mm_shuffle_epi32(v_s1_sum, 0x02));
+        let mut s1_buf = [0u32; 4];
+        let mut s2_buf = [0u32; 4];
+        _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
+        _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        let v_s2_sum = _mm_add_epi32(v_s2_128, _mm_shuffle_epi32(v_s2_128, 0x31));
-        let v_s2_sum = _mm_add_epi32(v_s2_sum, _mm_shuffle_epi32(v_s2_sum, 0x02));
-
-        s1 = (s1 as u64 + (_mm_cvtsi128_si32(v_s1_sum) as u32) as u64) as u32;
-        s2 = ((s2 as u64 + (_mm_cvtsi128_si32(v_s2_sum) as u32) as u64) % DIVISOR as u64) as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64)
+            as u32;
+        let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
+        s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
         s1 %= DIVISOR;
         s2 %= DIVISOR;
@@ -829,8 +834,9 @@ pub unsafe fn adler32_x86_avx2_vnni(adler: u32, p: &[u8]) -> u32 {
         let v_zero_xmm = _mm_setzero_si128();
 
         let sad = _mm_sad_epu8(d, v_zero_xmm);
-        let s1_part = (_mm_cvtsi128_si32(_mm_add_epi32(sad, _mm_unpackhi_epi64(sad, sad))) as u32)
-            as u64 as u32;
+        let mut buf = [0u32; 4];
+        _mm_storeu_si128(buf.as_mut_ptr() as *mut __m128i, sad);
+        let s1_part = (buf[0] as u64 + buf[2] as u64) as u32;
 
         s2 = ((s2 as u64 + s1 as u64 * 16) % DIVISOR as u64) as u32;
         s1 = (s1 as u64 + s1_part as u64) as u32;
@@ -841,8 +847,10 @@ pub unsafe fn adler32_x86_avx2_vnni(adler: u32, p: &[u8]) -> u32 {
 
         let s_sum = _mm_add_epi32(s, _mm_shuffle_epi32(s, 0x4E));
         let s_sum = _mm_add_epi32(s_sum, _mm_shuffle_epi32(s_sum, 0xB1));
+        let mut buf_s = [0u32; 4];
+        _mm_storeu_si128(buf_s.as_mut_ptr() as *mut __m128i, s_sum);
 
-        s2 = ((s2 as u64 + (_mm_cvtsi128_si32(s_sum) as u32) as u64) % DIVISOR as u64) as u32;
+        s2 = ((s2 as u64 + buf_s[0] as u64) % DIVISOR as u64) as u32;
 
         let processed = 16;
         data = &data[processed..];
@@ -1068,14 +1076,15 @@ pub unsafe fn adler32_x86_avx512_vnni(adler: u32, p: &[u8]) -> u32 {
             _mm256_extracti128_si256(v_s2_256, 1),
         );
 
-        let v_s1_sum = _mm_add_epi32(v_s1_128, _mm_shuffle_epi32(v_s1_128, 0x31));
-        let v_s1_sum = _mm_add_epi32(v_s1_sum, _mm_shuffle_epi32(v_s1_sum, 0x02));
+        let mut s1_buf = [0u32; 4];
+        let mut s2_buf = [0u32; 4];
+        _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
+        _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        let v_s2_sum = _mm_add_epi32(v_s2_128, _mm_shuffle_epi32(v_s2_128, 0x31));
-        let v_s2_sum = _mm_add_epi32(v_s2_sum, _mm_shuffle_epi32(v_s2_sum, 0x02));
-
-        s1 = (s1 as u64 + (_mm_cvtsi128_si32(v_s1_sum) as u32) as u64) as u32;
-        s2 = ((s2 as u64 + (_mm_cvtsi128_si32(v_s2_sum) as u32) as u64) % DIVISOR as u64) as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64)
+            as u32;
+        let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
+        s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
         s1 %= DIVISOR;
         s2 %= DIVISOR;

--- a/src/adler32/x86.rs
+++ b/src/adler32/x86.rs
@@ -544,8 +544,7 @@ pub unsafe fn adler32_x86_avx2(adler: u32, p: &[u8]) -> u32 {
         _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
         _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64)
-            as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64) as u32;
         let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
@@ -820,8 +819,7 @@ pub unsafe fn adler32_x86_avx2_vnni(adler: u32, p: &[u8]) -> u32 {
         _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
         _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64)
-            as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64) as u32;
         let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
@@ -1081,8 +1079,7 @@ pub unsafe fn adler32_x86_avx512_vnni(adler: u32, p: &[u8]) -> u32 {
         _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
         _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64)
-            as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64) as u32;
         let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 


### PR DESCRIPTION
For large dense blocks of data (e.g. 0xFF repeats over a full 4096-byte chunk), the internal 32-bit SIMD accumulators (like v_s1_sums in AVX2/AVX512) can exceed 2.14 billion per lane. While these values individually fit within unsigned 32-bit bounds, horizontal reductions using _mm_add_epi32 or similar signed addition instructions cause silent wrapping overflow inside the vector before they can be scalarized via _mm_cvtsi128_si32. This corrupted the checksum prior to the modulo DIVISOR operation.

Fix this by cleanly storing the individual 32-bit vector lanes into an array buffer and accumulating them in a 64-bit scalar loop. This applies to SSE2, AVX2, and AVX512 implementations.

---
*PR created automatically by Jules for task [5379425968420516824](https://jules.google.com/task/5379425968420516824) started by @404Setup*