### PR TITLE
refactor: streamline tail loop in decompress_offset_cycle4

### DIFF
--- a/src/adler32/x86.rs
+++ b/src/adler32/x86.rs
@@ -535,8 +535,16 @@ pub unsafe fn adler32_x86_avx2(adler: u32, p: &[u8]) -> u32 {
         _mm256_storeu_si256(s1_buf.as_mut_ptr() as *mut __m256i, v_s1);
         _mm256_storeu_si256(s2_buf.as_mut_ptr() as *mut __m256i, v_s2);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64 + s1_buf[4] as u64 + s1_buf[6] as u64) as u32;
-        let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64 + s2_buf[4] as u64 + s2_buf[5] as u64 + s2_buf[6] as u64 + s2_buf[7] as u64;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[2] as u64 + s1_buf[4] as u64 + s1_buf[6] as u64)
+            as u32;
+        let s2_sum = s2_buf[0] as u64
+            + s2_buf[1] as u64
+            + s2_buf[2] as u64
+            + s2_buf[3] as u64
+            + s2_buf[4] as u64
+            + s2_buf[5] as u64
+            + s2_buf[6] as u64
+            + s2_buf[7] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
         s1 %= DIVISOR;
@@ -810,7 +818,8 @@ pub unsafe fn adler32_x86_avx2_vnni(adler: u32, p: &[u8]) -> u32 {
         _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
         _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64) as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64)
+            as u32;
         let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 
@@ -1070,7 +1079,8 @@ pub unsafe fn adler32_x86_avx512_vnni(adler: u32, p: &[u8]) -> u32 {
         _mm_storeu_si128(s1_buf.as_mut_ptr() as *mut __m128i, v_s1_128);
         _mm_storeu_si128(s2_buf.as_mut_ptr() as *mut __m128i, v_s2_128);
 
-        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64) as u32;
+        s1 = (s1 as u64 + s1_buf[0] as u64 + s1_buf[1] as u64 + s1_buf[2] as u64 + s1_buf[3] as u64)
+            as u32;
         let s2_sum = s2_buf[0] as u64 + s2_buf[1] as u64 + s2_buf[2] as u64 + s2_buf[3] as u64;
         s2 = ((s2 as u64 + s2_sum) % DIVISOR as u64) as u32;
 

--- a/src/decompress/x86.rs
+++ b/src/decompress/x86.rs
@@ -561,39 +561,19 @@ unsafe fn decompress_offset_cycle4<const SHIFT: i32>(
         copied += 64;
     }
 
-    loop {
-        if copied + 16 > length {
-            break;
-        }
+    if copied + 16 <= length {
         _mm_storeu_si128(out_next.add(copied) as *mut __m128i, v1);
         copied += 16;
 
-        if copied + 16 > length {
-            break;
-        }
-        _mm_storeu_si128(out_next.add(copied) as *mut __m128i, v2);
-        copied += 16;
+        if copied + 16 <= length {
+            _mm_storeu_si128(out_next.add(copied) as *mut __m128i, v2);
+            copied += 16;
 
-        if copied + 16 > length {
-            break;
+            if copied + 16 <= length {
+                _mm_storeu_si128(out_next.add(copied) as *mut __m128i, v3);
+                copied += 16;
+            }
         }
-        _mm_storeu_si128(out_next.add(copied) as *mut __m128i, v3);
-        copied += 16;
-
-        if copied + 16 > length {
-            break;
-        }
-        let next_v0 = _mm_alignr_epi8::<SHIFT>(v1, v0);
-        _mm_storeu_si128(out_next.add(copied) as *mut __m128i, next_v0);
-        copied += 16;
-
-        let next_v1 = _mm_alignr_epi8::<SHIFT>(v2, v1);
-        let next_v2 = _mm_alignr_epi8::<SHIFT>(v3, v2);
-        let next_v3 = _mm_alignr_epi8::<SHIFT>(next_v0, v3);
-        v0 = next_v0;
-        v1 = next_v1;
-        v2 = next_v2;
-        v3 = next_v3;
     }
 
     if copied < length {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was a lengthy, confusing, and mathematically unreachable set of dead code within an infinite `loop` tail block in `src/decompress/x86.rs:decompress_offset_cycle4`.
💡 **Why:** The preceding processing block guarantees the remaining chunk length is less than 64. Using an infinite `loop` with repeated checks and variable reassignment that will never be reached added mental overhead and cluttered the optimized routine. We replaced it with the identical `if` nesting pattern used elsewhere.
✅ **Verification:** Ran `cargo test`, verified no functionally was broken (all tests passed), validated formatting with `cargo fmt`, and requested code review resulting in a clean `#Correct#` rating.
✨ **Result:** Improved maintainability, cleaner code, and removal of dead SIMD calculations in a highly optimized file.

---
*PR created automatically by Jules for task [6417813736044033527](https://jules.google.com/task/6417813736044033527) started by @404Setup*